### PR TITLE
chore(infra): codify instruction workflow invariants

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -46,10 +46,29 @@ ADR required before committing to either Terraform or Bicep — see issue #22.
 
 ---
 
+## Workflow invariants
+
+- This repo is the gitlink path `infrastructure` inside `aharbii/movie-finder`. Parent
+  workflow/path filters must use `infrastructure`, not `infrastructure/**`.
+- Cross-repo tracker issues originate in `aharbii/movie-finder`. Create the linked child issue in
+  this repo only if this repo will actually change.
+- Inspect `.github/ISSUE_TEMPLATE/*.yml`, `.github/PULL_REQUEST_TEMPLATE.md` when present, and a
+  recent example before creating or editing issues/PRs. Do not improvise titles or bodies.
+- For child issues in this repo, use `.github/ISSUE_TEMPLATE/linked_task.yml` and keep the
+  description, file references, and acceptance criteria repo-specific.
+- If CI, required checks, or merge policy changes affect this repo, update contributor-facing docs
+  here and in `aharbii/movie-finder` where relevant.
+- If a new standalone issue appears mid-session, branch from `main` unless stacking is explicitly
+  requested.
+- PR descriptions must disclose the AI authoring tool + model. Any AI-assisted review comment or
+  approval must also disclose the review tool + model.
+
+---
+
 ## Cross-cutting — check for every change
 
-1. GitHub issue in `aharbii/movie-finder` + this repo (linked)
-2. Branch: `feature/`, `chore/` (kebab-case)
+1. GitHub issue in `aharbii/movie-finder` + linked child issue here only if this repo changes, using the current templates and recent examples
+2. Branch: `feature/`, `chore/` (kebab-case) from `main` unless stacking is explicitly requested
 3. **ADR required** for any new Azure resource, cloud provider decision, or IaC toolchain choice
 4. New secrets → update `.env.example` in all affected repos + flag for Key Vault + Jenkins credentials store
 5. New Azure resources → update `docs/architecture/10-deployment-azure.puml` + Structurizr `workspace.dsl`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,30 @@ IaC (Terraform/Bicep) for Azure provisioning (ACR, Key Vault, Container Apps).
 
 ---
 
+## Workflow invariants
+
+- This repo is the gitlink path `infrastructure` inside `aharbii/movie-finder`. Parent
+  workflow/path filters must use `infrastructure`, not `infrastructure/**`.
+- Cross-repo tracker issues originate in `aharbii/movie-finder`. Create the linked child issue in
+  this repo only if this repo will actually change.
+- Inspect `.github/ISSUE_TEMPLATE/*.yml`, `.github/PULL_REQUEST_TEMPLATE.md` when present, and a
+  recent example before creating or editing issues/PRs. Do not improvise titles or bodies.
+- For child issues in this repo, use `.github/ISSUE_TEMPLATE/linked_task.yml` and keep the
+  description, file references, and acceptance criteria repo-specific.
+- If CI, required checks, or merge policy changes affect this repo, update contributor-facing docs
+  here and in `aharbii/movie-finder` where relevant.
+- If a new standalone issue appears mid-session, branch from `main` unless stacking is explicitly
+  requested.
+- PR descriptions must disclose the AI authoring tool + model. Any AI-assisted review comment or
+  approval must also disclose the review tool + model.
+
+---
+
 ## VSCode setup
 
 `infrastructure/.vscode/` — workspace configuration for IaC editing.
 - `settings.json`: Terraform/Bicep formatter placeholders (uncomment once issue #22 tooling is chosen)
 - `extensions.json`: `hashicorp.terraform`, `ms-azuretools.vscode-bicep`, `ms-azuretools.azure-resources`, Docker, YAML
 - Modifying configs: uncomment the relevant formatter block once IaC tooling is decided.
-  Update `CLAUDE.md`, `GEMINI.md`, and `AGENTS.md` after.
+  Update `CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, and the repo's `.github/copilot-instructions.md`
+  after.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,34 @@ See `docs/devops-setup.md §9` for the full credential table. Common IDs:
 
 ---
 
+## Workflow invariants
+
+- This repo is the gitlink path `infrastructure` inside `aharbii/movie-finder`. Parent
+  workflow/path filters must use `infrastructure`, not `infrastructure/**`.
+- Cross-repo tracker issues originate in `aharbii/movie-finder`. Create the linked child issue in
+  this repo only if this repo will actually change.
+- Inspect `.github/ISSUE_TEMPLATE/*.yml`, `.github/PULL_REQUEST_TEMPLATE.md` when present, and a
+  recent example before creating or editing issues/PRs. Do not improvise titles or bodies.
+- For child issues in this repo, use `.github/ISSUE_TEMPLATE/linked_task.yml` and keep the
+  description, file references, and acceptance criteria repo-specific.
+- If CI, required checks, or merge policy changes affect this repo, update contributor-facing docs
+  here and in `aharbii/movie-finder` where relevant.
+- If a new standalone issue appears mid-session, branch from `main` unless stacking is explicitly
+  requested.
+- PR descriptions must disclose the AI authoring tool + model. Any AI-assisted review comment or
+  approval must also disclose the review tool + model.
+
+---
+
 ## Session start protocol
 
 1. `gh issue list --repo aharbii/movie-finder --state open`
 2. Verify issue #22 status before starting IaC work — check what currently exists
-3. Create issue in `aharbii/movie-finder`, then `aharbii/movie-finder-infrastructure`
-4. Create branch + work through checklist
+3. Inspect `.github/ISSUE_TEMPLATE/*.yml`, `.github/PULL_REQUEST_TEMPLATE.md` when present, and a
+   recent example of the same type
+4. Create the parent issue in `aharbii/movie-finder`, then the linked child issue in
+   `aharbii/movie-finder-infrastructure` only if this repo will actually change
+5. Create a branch from `main` and work through the checklist
 
 ---
 
@@ -112,10 +134,12 @@ Conventional Commits: `chore(infra): add Key Vault secret for Gemini API key`
 
 ### 1. GitHub issues
 - [ ] `aharbii/movie-finder` (parent)
-- [ ] `aharbii/movie-finder-infrastructure` linked
+- [ ] `aharbii/movie-finder-infrastructure` linked child issue only if this repo changes
+- [ ] Matching issue/PR templates and a recent example were inspected before filing or editing
 
 ### 2. Branch
 - [ ] Branch in this repo + `chore/` in root `movie-finder` to bump pointer
+- [ ] New standalone issues branch from `main` unless stacking is explicitly requested
 
 ### 3. ADR
 - [ ] New Azure service, new cloud provider, or new secrets architecture decision?
@@ -134,7 +158,7 @@ Conventional Commits: `chore(infra): add Key Vault secret for Gemini API key`
 - [ ] `docs/devops-setup.md` credentials table updated
 
 ### 6. CI — Jenkins
-- [ ] Any Jenkinsfile changes needed (new credentials, new deploy steps)?
+- [ ] `.github/workflows/*.yml` and/or Jenkinsfile reviewed for new credentials, permissions, or deploy steps
 - [ ] Jenkins pipeline mode (INTEGRATION / RELEASE) still valid for new resources?
 
 ### 7. Architecture diagrams (in `docs/` submodule)
@@ -146,6 +170,7 @@ Conventional Commits: `chore(infra): add Key Vault secret for Gemini API key`
 ### 8. Documentation
 - [ ] `docs/devops-setup.md` updated (new resources, access patterns, credentials)
 - [ ] `CHANGELOG.md` under `[Unreleased]`
+- [ ] Contributor docs updated when CI, required checks, or merge policy change
 
 ### 9. Sibling submodules affected
 | Submodule | Why |
@@ -161,5 +186,6 @@ git add infrastructure && git commit -m "chore(infra): bump to latest main"
 ```
 
 ### 11. Pull request
-- [ ] PR in `aharbii/movie-finder-infrastructure`
+- [ ] PR in `aharbii/movie-finder-infrastructure` discloses the AI authoring tool + model
 - [ ] PR in `aharbii/movie-finder` (pointer bump)
+- [ ] Any AI-assisted review comment or approval discloses the review tool + model

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -24,6 +24,25 @@ IaC (Terraform/Bicep) for Azure provisioning (ACR, Key Vault, Container Apps).
 
 ---
 
+## Workflow invariants
+
+- This repo is the gitlink path `infrastructure` inside `aharbii/movie-finder`. Parent
+  workflow/path filters must use `infrastructure`, not `infrastructure/**`.
+- Cross-repo tracker issues originate in `aharbii/movie-finder`. Create the linked child issue in
+  this repo only if this repo will actually change.
+- Inspect `.github/ISSUE_TEMPLATE/*.yml`, `.github/PULL_REQUEST_TEMPLATE.md` when present, and a
+  recent example before creating or editing issues/PRs. Do not improvise titles or bodies.
+- For child issues in this repo, use `.github/ISSUE_TEMPLATE/linked_task.yml` and keep the
+  description, file references, and acceptance criteria repo-specific.
+- If CI, required checks, or merge policy changes affect this repo, update contributor-facing docs
+  here and in `aharbii/movie-finder` where relevant.
+- If a new standalone issue appears mid-session, branch from `main` unless stacking is explicitly
+  requested.
+- PR descriptions must disclose the AI authoring tool + model. Any AI-assisted review comment or
+  approval must also disclose the review tool + model.
+
+---
+
 ## VSCode setup
 
 `infrastructure/.vscode/` — workspace configuration for IaC editing.


### PR DESCRIPTION
## What and why

Closes #6

This codifies repo-specific workflow invariants in the instruction files so future sessions stop drifting from the live issue and PR templates.

It adds explicit rules for:
- inspecting the matching issue and PR templates plus a recent example before filing
- creating linked child issues only when this repo actually changes
- treating this repo as the parent gitlink path infrastructure in aharbii/movie-finder
- updating contributor docs when CI, required checks, or merge policy change
- disclosing AI authoring and AI-assisted review metadata

## How to test

1. Review AGENTS.md, CLAUDE.md, GEMINI.md, and .github/copilot-instructions.md.
2. Confirm the workflow invariants cover template inspection, linked child issue creation, parent gitlink semantics, CI/documentation coupling, branch-from-main guidance, and AI disclosure.
3. Run git diff --check.

## AI disclosure

- AI authoring tool: OpenAI Codex CLI
- Model: GPT-5
- AI-assisted review: none yet
