### PR TITLE
docs(infra): clarify backend runtime config

### DIFF
--- a/docs/qdrant-secret-model.md
+++ b/docs/qdrant-secret-model.md
@@ -140,6 +140,8 @@ make real API calls. At runtime, env vars are inherited from the hosting `app/` 
 Backend runtime also uses non-secret app settings that are not stored in Key Vault:
 `CORS_ORIGINS`, `GLOBAL_RATE_LIMIT`, `AUTH_RATE_LIMIT`, `CHAT_RATE_LIMIT`, and
 `MAX_MESSAGE_LENGTH`. Treat these as deployment-time configuration, not secrets.
+Set them in the Azure Container App environment variables, the Docker Compose
+`environment:` block for local development, or the backend `.env` file.
 
 ---
 

--- a/docs/qdrant-secret-model.md
+++ b/docs/qdrant-secret-model.md
@@ -137,6 +137,10 @@ make real API calls. At runtime, env vars are inherited from the hosting `app/` 
 | `LANGSMITH_ENDPOINT`     | ✓ (opt-in)  | ✓ (opt-in, dev) |           —           |    —     |
 | `LANGSMITH_PROJECT`      | ✓ (opt-in)  | ✓ (opt-in, dev) |           —           |    —     |
 
+Backend runtime also uses non-secret app settings that are not stored in Key Vault:
+`CORS_ORIGINS`, `GLOBAL_RATE_LIMIT`, `AUTH_RATE_LIMIT`, `CHAT_RATE_LIMIT`, and
+`MAX_MESSAGE_LENGTH`. Treat these as deployment-time configuration, not secrets.
+
 ---
 
 ## 4. Dependency notes


### PR DESCRIPTION
## What and why

Closes #12

Align the infrastructure secret-model docs with the backend runtime contract landed in `movie-finder-backend#17` and the checkpoint/runtime alignment tracked from `movie-finder#2` and `movie-finder#18`.

This clarifies that `CORS_ORIGINS`, `GLOBAL_RATE_LIMIT`, `AUTH_RATE_LIMIT`, `CHAT_RATE_LIMIT`, and `MAX_MESSAGE_LENGTH` are deployment-time backend app settings, not Key Vault secrets. The goal is to keep the infrastructure docs accurate for operators without implying these values should be managed as secret material.

## Type of change

- [ ] New Azure resource or IaC module
- [ ] Secret naming convention change or Key Vault update
- [ ] Jenkins credential addition or rename
- [ ] Provisioning script update
- [x] Documentation only (setup guide, secret model)

## How to test

1. Open `docs/qdrant-secret-model.md`.
2. Verify the backend runtime settings are described as non-secret deployment-time configuration.
3. Confirm the wording stays consistent with `movie-finder-backend#17` and the parent docs updates.

## Checklist

### Secrets and credentials

- [ ] New secrets added to Azure Key Vault manually (never in source code)
- [ ] New Jenkins credentials added to the Jenkins credentials store (if needed at CI time)
- [ ] `.env.example` updated in **every affected repo** with the new variable names
- [x] `docs/qdrant-secret-model.md` updated if Qdrant or other secret names changed
- [ ] `docs/devops/setup.md` credentials table updated

### IaC _(if applicable)_

- [x] No secrets, credentials, or internal URLs hard-coded in IaC files
- [ ] `terraform validate` / `az deployment validate` passes (or explicitly noted as untested)
  Not applicable: docs-only change.
- [ ] Idempotent: applying the same change twice produces no error
  Not applicable: docs-only change.

### Documentation

- [ ] `CHANGELOG.md` updated under `[Unreleased]`
  Not applicable: docs-only clarification.
- [ ] `README.md` updated if the repository structure or provisioning steps changed
  Not applicable: no repo-structure or provisioning-step change.

### Review

- [x] PR title follows `chore(infra): summary` or `docs(infra): summary` (≤72 chars, lowercase)
- [x] PR description links the issue and discloses the AI authoring tool + model used
- [ ] Any AI-assisted review comment or approval discloses the review tool + model

## AI disclosure

- AI authoring tool: OpenAI Codex CLI
- Model: GPT-5 Codex
- AI-assisted review: none yet
